### PR TITLE
Fix broken Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ __data.json__
 $ jtl --expr "domain" a.jtl
 "dykman.org"
 ```
+```
 $ jtl --expr "author" a.jtl
 "michael"
 ```


### PR DESCRIPTION
A missing code block delimiter broke a section of markdown here in the README